### PR TITLE
Fix windows credential manager access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,8 +410,7 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 [[package]]
 name = "keyring"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bcd64f48199f69993c705fd2f76882e53969db93bc6345021bc8bb6462a9ffa"
+source = "git+https://github.com/adobeDan/keyring-rs?branch=master#5b3cefbc74a604c803ced09608b39529c9c86801"
 dependencies = [
  "byteorder",
  "secret-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ base64 = "0.13.0"
 shellexpand = "2.0.0"
 chrono = "0.4.19"
 glob = "0.3.0"
-keyring = "0.10.1"
+keyring = { git = "https://github.com/adobeDan/keyring-rs", branch = "master" }
 eyre = "0.6.5"
 visdom = "0.4.0"
 zip = "0.5.11"

--- a/src/types.rs
+++ b/src/types.rs
@@ -133,8 +133,6 @@ impl OperatingConfig {
             .as_str()
         {
             self.expiry_date = date_from_epoch_millis(expiry_timestamp)?;
-        } else if let Ok(expiry_timestamp) = self.get_cached_expiry() {
-            self.expiry_date = date_from_epoch_millis(&expiry_timestamp)?;
         } else {
             self.expiry_date = "controlled by server".to_string();
         }
@@ -217,9 +215,10 @@ fn get_saved_credential(key: &str) -> Result<String> {
 fn get_saved_credential(key: &str) -> Result<String> {
     let mut result = String::new();
     for i in 1..100 {
-        let service = format!("Adobe App Info ({})(Part{})", &key, i);
+        let service = format!("Adobe App Info ({})(Part{})", key, i);
         let keyring = keyring::Keyring::new(&service, "App Info");
-        if let Ok(note) = keyring.get_password() {
+        let note = keyring.get_password_for_target(&service);
+        if let Ok(note) = note {
             result.push_str(note.trim());
         } else {
             break;


### PR DESCRIPTION
## Description
Windows NGL uses a completely different credential store mechanism than Mac NGL, because on Windows the credential store size per entry is quite limited.  So this PR introduces knowledge of how NGL splits the cached license across multiple credential entries.  It also includes a fix for an issue (hwchen/keyring-rs#60), discovered during testing, in the `keychain-rs` Rust crate.

## Related Issue
This is an extension to the fix of #7.  It also removes two code lines that were accidentally re-introduced during an earlier merge that caused unnecessary credential store accesses even when `-vv` is not specified.

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
