### PR TITLE
Enhance CI/CD to produce and post native builds for Apple Silicon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,33 +7,38 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        arch: [x86_64-apple-darwin, aarch64-apple-darwin, x86_64-pc-windows-msvc]
+        include:
+          - arch: x86_64-pc-windows-msvc
+            os: windows-latest
+          - arch: x86_64-apple-darwin
+            os: macos-latest
+          - arch: aarch64-apple-darwin
+            os: macos-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: upgrade XCode
+        uses: maxim-lobanov/setup-xcode@v1
+        if: ${{ matrix.os == 'macos-latest' }}
+        with:
+          xcode-version: latest-stable
 
-      - uses: actions-rs/toolchain@v1
+      - name: XCode build target to aarch64-apple-darwin
+        run: |
+          echo SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path) >> $GITHUB_ENV
+          echo MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version) >> $GITHUB_ENV
+        if: ${{ matrix.arch == 'aarch64-apple-darwin' }}
+
+      - name: fetch head
+        uses: actions/checkout@v2
+
+      - name: install Rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          target: ${{ matrix.arch }}
           toolchain: stable
-          override: true
           components: rustfmt, clippy
-
-      - name: Build debug
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-
-      - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-
-      - name: Build release locked
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --locked
 
       - name: Format check
         uses: actions-rs/cargo@v1
@@ -47,10 +52,29 @@ jobs:
           command: clippy
           args: -- -D warnings
 
+      - name: Build debug
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target ${{ matrix.arch }}
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        if: ${{ matrix.arch != 'aarch64-apple-darwin' }}
+        with:
+          command: test
+          args: --target ${{ matrix.arch }}
+
+      - name: Build release locked
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args:  --target ${{ matrix.arch }} --release --locked
+
       - name: Upload executables
         uses: actions/upload-artifact@v2
         with:
           name: executables
           path: |
-            target/*/adobe-license-decoder
-            target/*/adobe-license-decoder.exe
+            target/**/adobe-license-decoder
+            target/**/adobe-license-decoder.exe

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,33 +10,54 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        arch: [x86_64-apple-darwin, aarch64-apple-darwin, x86_64-pc-windows-msvc]
         include:
-          - os: windows-latest
-            artifact_name: adobe-license-decoder.exe
-            asset_name: adobe-license-decoder.exe
-          - os: macos-latest
-            artifact_name: adobe-license-decoder
-            asset_name: adobe-license-decoder
+          - arch: x86_64-pc-windows-msvc
+            os: windows-latest
+            executable_name: adobe-license-decoder.exe
+            posted_name: adobe-license-decoder.windows_x86_64.exe
+          - arch: x86_64-apple-darwin
+            os: macos-latest
+            executable_name: adobe-license-decoder
+            posted_name: adobe-license-decoder.mac_x86_64
+          - arch: aarch64-apple-darwin
+            os: macos-latest
+            executable_name: adobe-license-decoder
+            posted_name: adobe-license-decoder.mac_arm64
 
     steps:
-      - uses: actions/checkout@v2
+      - name: upgrade XCode
+        uses: maxim-lobanov/setup-xcode@v1
+        if: ${{ matrix.os == 'macos-latest' }}
+        with:
+          xcode-version: latest-stable
 
-      - uses: actions-rs/toolchain@v1
+      - name: XCode build target to aarch64-apple-darwin
+        run: |
+          echo SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path) >> $GITHUB_ENV
+          echo MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version) >> $GITHUB_ENV
+        if: ${{ matrix.arch == 'aarch64-apple-darwin' }}
+
+      - name: fetch head
+        uses: actions/checkout@v2
+
+      - name: install Rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          target: ${{ matrix.arch }}
           toolchain: stable
-          override: true
 
       - name: Build release locked
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --locked
+          args:  --target ${{ matrix.arch }} --release --locked
 
       - name: Post release executable
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/release/${{ matrix.artifact_name }}
-          asset_name: ${{ matrix.asset_name }}
+          file: target/${{ matrix.arch }}/release/${{ matrix.executable_name }}
+          asset_name: ${{ matrix.posted_name }}
           tag: ${{ github.ref }}


### PR DESCRIPTION
## Description
Our existing CI/CD pipeline only build for x86_64 hardware on both Mac and Windows.  Now that Apple is selling M1-based machines, and Adobe is producing native product builds for those machines, we need the adobe-license-decoder to support those machines.

## Related Issue
Fixes #8.

## Tasks
No testing needed, since no functional changes, other than to verify that the posted builds are actually arm64-native.

- [x] I have signed the [CLA](http://adobe.github.io/cla.html).
- [x] I have written tests and verified that they fail without my change.
